### PR TITLE
Remove TODO from summary

### DIFF
--- a/bootstrap-datepicker.gemspec
+++ b/bootstrap-datepicker.gemspec
@@ -8,8 +8,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Ilya Rogozin"]
   s.email       = ["ilya.rogozin@gmail.com"]
   s.homepage    = ""
-  s.summary     = %q{Panters bootstrap-datepicker}
-  # s.description = %q{TODO: Write a gem description}
+  s.summary     = %q{Twitter Bootstrap Datepicker for Rails}
 
   s.rubyforge_project = "bootstrap-datepicker"
 

--- a/bootstrap-datepicker.gemspec
+++ b/bootstrap-datepicker.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.authors     = ["Ilya Rogozin"]
   s.email       = ["ilya.rogozin@gmail.com"]
   s.homepage    = ""
-  s.summary     = %q{TODO: Write a gem summary}
-  s.description = %q{TODO: Write a gem description}
+  s.summary     = %q{Panters bootstrap-datepicker}
+  # s.description = %q{TODO: Write a gem description}
 
   s.rubyforge_project = "bootstrap-datepicker"
 


### PR DESCRIPTION
bundle 1.11.2 claims: bootstrap-datepicker.gemspec is not valid. The validation error was '"FIXME" or "TODO" is not a description'
